### PR TITLE
Fix invalid email syntax insertion of root user

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -57,7 +57,7 @@ or just execute:
 
 this command will pull illasoft official slim image and run it on your docker environment.
 
-And Login with default username **```root```** and password **```password```**.
+And Login with default username **```root```**, email **```root@test.com```** and password **```password```**.
 
 # Build Slim Image Manually and Run
 

--- a/docker-compose/postgres-init.sh
+++ b/docker-compose/postgres-init.sh
@@ -212,7 +212,7 @@ ALTER TABLE set_states
 alter table set_states
     owner to illa;
 
-INSERT INTO users (id, nickname, password_digest, email, language, is_subscribed, created_at, updated_at, uid) VALUES (DEFAULT, 'root', '\$2a\$10\$iVIxJRgy1K6RIV389AYg3OiMIbuDyuCIja1xrHGkCljdg/6gdmWXa', 'root', 1, false, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, DEFAULT);
+INSERT INTO users (id, nickname, password_digest, email, language, is_subscribed, created_at, updated_at, uid) VALUES (DEFAULT, 'root', '\$2a\$10\$iVIxJRgy1K6RIV389AYg3OiMIbuDyuCIja1xrHGkCljdg/6gdmWXa', 'root@test.com', 1, false, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, DEFAULT);
 
 EOF
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -54,7 +54,7 @@ or just execute:
 
 this command will pull illasoft official image and run it on your docker environment.
 
-And Login with default username **```root```** and password **```password```**.
+And Login with default username **```root```**, email **```root@test.com```** and password **```password```**.
 
 # Build Image Manually and Run
 

--- a/docker/postgres-init.sh
+++ b/docker/postgres-init.sh
@@ -212,7 +212,7 @@ ALTER TABLE set_states
 alter table set_states
     owner to illa;
 
-INSERT INTO users (id, nickname, password_digest, email, language, is_subscribed, created_at, updated_at, uid) VALUES (DEFAULT, 'root', '\$2a\$10\$iVIxJRgy1K6RIV389AYg3OiMIbuDyuCIja1xrHGkCljdg/6gdmWXa', 'root', 1, false, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, DEFAULT);
+INSERT INTO users (id, nickname, password_digest, email, language, is_subscribed, created_at, updated_at, uid) VALUES (DEFAULT, 'root', '\$2a\$10\$iVIxJRgy1K6RIV389AYg3OiMIbuDyuCIja1xrHGkCljdg/6gdmWXa', 'root@test.com', 1, false, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, DEFAULT);
 
 EOF
 


### PR DESCRIPTION
The sign in page only displays email, but not username. The email field in the record gives an invalid email that the frontend will not validate due to an incorrect syntax.